### PR TITLE
Move out requires from renderToHTML (#5915)

### DIFF
--- a/packages/next-server/server/get-dynamic-import-bundles.ts
+++ b/packages/next-server/server/get-dynamic-import-bundles.ts
@@ -5,7 +5,7 @@ export type ManifestItem = {
   publicPath: string
 }
 
-type Manifest = {[moduleId: string]: ManifestItem[]}
+export type Manifest = {[moduleId: string]: ManifestItem[]}
 
 type DynamicImportBundles = Set<ManifestItem>
 

--- a/packages/next-server/server/get-page-files.ts
+++ b/packages/next-server/server/get-page-files.ts
@@ -1,6 +1,7 @@
 import {normalizePagePath} from './require'
 
-type BuildManifest = {
+export type BuildManifest = {
+  devFiles: string[],
   pages: {
     [page: string]: string[]
   }

--- a/packages/next-server/server/load-components.ts
+++ b/packages/next-server/server/load-components.ts
@@ -1,0 +1,21 @@
+import {join} from 'path'
+import {CLIENT_STATIC_FILES_PATH, BUILD_MANIFEST, REACT_LOADABLE_MANIFEST, SERVER_DIRECTORY} from 'next-server/constants'
+import {requirePage} from './require'
+
+function interopDefault (mod: any) {
+  return mod.default || mod
+}
+
+export async function loadComponents (distDir: string, buildId: string, pathname: string) {
+  const documentPath = join(distDir, SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH, buildId, 'pages', '_document')
+  const appPath = join(distDir, SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH, buildId, 'pages', '_app')
+  let [buildManifest, reactLoadableManifest, Component, Document, App] = await Promise.all([
+    require(join(distDir, BUILD_MANIFEST)),
+    require(join(distDir, REACT_LOADABLE_MANIFEST)),
+    interopDefault(requirePage(pathname, distDir)),
+    interopDefault(require(documentPath)),
+    interopDefault(require(appPath))
+  ])
+
+  return {buildManifest, reactLoadableManifest, Component, Document, App}
+}

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -136,6 +136,8 @@ export default async function (dir, options, configuration) {
             env: process.env
           })
           worker.send({
+            distDir,
+            buildId,
             exportPaths: chunk.paths,
             exportPathMap: chunk.pathMap,
             outDir,

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -7,10 +7,13 @@ const mkdirp = require('mkdirp-then')
 const { renderToHTML } = require('next-server/dist/server/render')
 const { writeFile } = require('fs')
 const Sema = require('async-sema')
+const {loadComponents} = require('next-server/dist/server/load-components')
 
 process.on(
   'message',
   async ({
+    distDir,
+    buildId,
     exportPaths,
     exportPathMap,
     outDir,
@@ -37,7 +40,8 @@ process.on(
         const htmlFilepath = join(outDir, htmlFilename)
 
         await mkdirp(baseDir)
-        const html = await renderToHTML(req, res, page, query, renderOpts)
+        const components = await loadComponents(distDir, buildId, page)
+        const html = await renderToHTML(req, res, page, query, {...components, ...renderOpts})
         await new Promise((resolve, reject) =>
           writeFile(
             htmlFilepath,

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -3,11 +3,13 @@ import { join } from 'path'
 import HotReloader from './hot-reloader'
 import {route} from 'next-server/dist/server/router'
 import {PHASE_DEVELOPMENT_SERVER} from 'next-server/constants'
+import ErrorDebug from './error-debug'
 
 export default class DevServer extends Server {
   constructor (options) {
     super(options)
     this.renderOpts.dev = true
+    this.renderOpts.ErrorDebug = ErrorDebug
     this.devReady = new Promise(resolve => {
       this.setDevReady = resolve
     })


### PR DESCRIPTION
This brings us one step closer to outputting serverless functions as renderToHTML now renders the passed components, which allows us to bundle the renderToHTML function together with statically imported components in webpack.