### PR TITLE
fix: update with-mobx example (#5936)

### DIFF
--- a/examples/with-mobx/README.md
+++ b/examples/with-mobx/README.md
@@ -47,7 +47,8 @@ This example is a mobx port of the [with-redux](https://github.com/zeit/next.js/
     "next/babel"
   ],
   "plugins": [
-    "transform-decorators-legacy"
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-class-properties", { "loose": true }]
   ]
 }
 ```


### PR DESCRIPTION
Babel related content in README.md is updated according to the updated .babelrc