### PR TITLE
Bugfix/redux saga 1 0 0 not ready (#6176)

### DIFF
--- a/examples/with-redux-saga/package.json
+++ b/examples/with-redux-saga/package.json
@@ -8,18 +8,18 @@
     "start": "next start"
   },
   "dependencies": {
-    "es6-promise": "4.2.5",
-    "isomorphic-unfetch": "3.0.0",
+    "es6-promise": "4.1.1",
+    "isomorphic-unfetch": "2.0.0",
     "next": "latest",
     "next-redux-saga": "3.0.0",
-    "next-redux-wrapper": "2.1.0",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
-    "react-redux": "6.0.0",
-    "redux": "4.0.1",
-    "redux-saga": "1.0.0"
+    "next-redux-wrapper": "2.0.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-redux": "5.0.7",
+    "redux": "4.0.0",
+    "redux-saga": "0.16.0"
   },
   "devDependencies": {
-    "redux-devtools-extension": "2.13.7"
+    "redux-devtools-extension": "2.13.2"
   }
 }

--- a/examples/with-redux-saga/saga.js
+++ b/examples/with-redux-saga/saga.js
@@ -1,6 +1,7 @@
 /* global fetch */
 
-import { all, call, delay, put, take, takeLatest } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
+import { all, call, put, take, takeLatest } from 'redux-saga/effects'
 import es6promise from 'es6-promise'
 import 'isomorphic-unfetch'
 
@@ -12,7 +13,7 @@ function * runClockSaga () {
   yield take(actionTypes.START_CLOCK)
   while (true) {
     yield put(tickClock(false))
-    yield delay(1000)
+    yield call(delay, 1000)
   }
 }
 


### PR DESCRIPTION
This reverts the changes made in [this pr](https://github.com/zeit/next.js/pull/6109).
`redux-saga: "1.0.0"` changed the way it handles it's queues. Because of that we're still having trouble to implement the synchronous side-effects flow in `next-redux-saga`. See [this discussion](https://github.com/bbortt/next-redux-saga/pull/1) for more information.
Therefore I would feel more comfortable not to mislead users by giving them a non-working example in the main branch.